### PR TITLE
ci(fro-bot): harden autoheal prompt with tighter guardrails and scope

### DIFF
--- a/.github/workflows/fro-bot-autoheal.yaml
+++ b/.github/workflows/fro-bot-autoheal.yaml
@@ -23,14 +23,43 @@ env:
   AUTOHEAL_PROMPT: |
     Perform daily repository autohealing for mrbro.dev — a React 19+ /
     TypeScript / Vite 7+ portfolio deployed to GitHub Pages.
-    Work through each category in order and prioritize minimal, reversible
-    changes. Read AGENTS.md for full project conventions before making changes.
+    Read AGENTS.md for full project conventions before making changes.
+
+    EXECUTION MODEL
+    Analyze all categories independently, but perform write actions serially.
+    Do not keep multiple branches checked out at once. Complete one mutation,
+    return to a clean working tree, then continue.
+
+    DEDUPLICATION (applies to ALL categories)
+    Before creating any new PR or issue, search for an existing open
+    bot-authored PR/issue for the same root cause. Reuse or update the
+    existing item instead of creating a duplicate.
+
+    SCOPE CAP
+    If the smallest safe fix is not clearly minimal and reversible (e.g.,
+    broad refactor, architecture change, or many-file edit), do not
+    auto-heal it. Open or update an issue and log it under "Needs Human
+    Attention".
+
+    DEPENDENCY OWNERSHIP
+    Renovate owns routine dependency/version bumps. You may change dependency
+    versions only when remediating a confirmed security advisory
+    (critical/high) or repairing an existing security-update PR. Do not
+    create non-security version-bump PRs, and do not batch unrelated
+    dependency changes into a security fix. Do NOT modify package.json
+    versions outside category 2 security remediation.
 
     1. ERRORED PRs
-       Find open PRs with failing CI checks. Only fix PRs whose branch
-       belongs to this repository (not forks). If a PR is from a fork or
-       the branch is not writable, skip it and log it under "Needs Human
-       Attention" in the summary.
+       Find open PRs with failing CI checks. Skip dependency/security update
+       PRs here; handle them only in category 2.
+       Only fix PRs whose head branch is in this repository, writable by
+       this token, and authored by a trusted source (repository
+       owner/collaborator with write access, or an approved automation bot
+       such as Renovate/Dependabot). If author trust cannot be established,
+       skip the PR and log it under "Needs Human Attention".
+       If the PR touches workflows, automation prompts, package-manager
+       config, lockfiles, or execution scripts, do not run project commands
+       from that branch. Skip it and log why.
        For each fixable PR:
        a. Check out the PR branch.
        b. Read the failing check logs to diagnose the root cause.
@@ -46,20 +75,41 @@ env:
        - For unaddressed critical/high advisories with no existing PR,
          create a new PR with the remediation.
        - Do NOT bulk-update unrelated deps in a security PR.
+       If security advisory/alert data is unavailable to the token or CLI,
+       skip this category and note "security alerts unavailable" under
+       "Needs Human Attention". Do not guess.
 
-    3. HEALTH & MAINTENANCE
-       Check for outdated dependencies:
-       - package.json: major version bumps.
-       - GitHub Actions workflow files: pin unpinned actions to full SHA;
-         update outdated pinned SHAs.
-       Create one PR per major dependency bump. Do NOT combine unrelated
-       upgrades.
+    3. CODE QUALITY & REPO HYGIENE
+       This category is primarily report-only. Focus on things only a
+       code-aware agent can catch:
+       - Run `pnpm build` and `pnpm run analyze-build`. Use the analysis
+         output to verify bundle budgets (JS <500KB warning, total <2MB
+         max). If over budget, open or update a single issue with the
+         offending chunks and sizes.
+       - Run tests in coverage mode (`pnpm test -- --coverage`) and verify
+         the enforced 80% thresholds for statements/branches/functions/
+         lines. If coverage fails, open or update a single issue with the
+         failing metrics and the top contributing files. Do not attempt
+         historical regression analysis unless a concrete baseline is
+         already available in the repository or workflow artifacts.
+       - Scan for stale TODO/FIXME/HACK annotations older than 90 days
+         (use git blame). Collect them into a single issue or update an
+         existing "Stale TODOs" issue.
+       - Verify convention compliance: hook files in src/hooks/ use
+         PascalCase, no barrel exports outside src/types/index.ts, no
+         CommonJS require() calls, no `any` type annotations/assertions.
+         Report findings but put actual code fixes into category 4.
+       - Check that AGENTS.md accurately reflects the current directory
+         structure and file counts. If drift is found, open a PR with
+         corrections.
 
     4. DEVELOPER EXPERIENCE
        Ensure consistent linting, formatting, and static analysis.
-       Run `pnpm lint` and `pnpm exec tsc --noEmit`; fix any failures.
+       Run `pnpm lint`; run `pnpm exec tsc --noEmit` only if type-checking
+       is not already covered by the build in category 3. Fix any failures,
+       including convention violations found in category 3.
        Open a PR for all fixes — never commit directly to the default
-       branch. Group related lint/format fixes into a single PR.
+       branch. Group related lint/format/convention fixes into a single PR.
 
     5. PRODUCTION SITE REVIEW
        Use `npx agent-browser` to review the live site at https://mrbro.dev.
@@ -82,7 +132,14 @@ env:
          snapshot).
        - No broken images or missing assets.
        - Mobile responsiveness: resize viewport to 375px width and verify
-         layout is not broken.
+         layout is not broken. "Broken" means: horizontal overflow, clipped
+         or overlapping text, inaccessible primary navigation, or content
+         extending beyond the viewport.
+
+       Retry logic: before creating an issue for a browser finding, rerun
+       the failing check once in a fresh page/session. Only file an issue
+       if the problem reproduces twice or is a hard failure (blank page,
+       broken navigation, missing asset, 4xx/5xx).
 
        Before creating an issue for a finding, search open issues for an
        existing report matching the same page and symptom. If a matching
@@ -91,7 +148,9 @@ env:
 
        For new issues, create a GitHub issue with:
        - Page URL and description of the problem.
-       - Screenshot evidence (attach or reference).
+       - Screenshot filename/path and a short text description of what it
+         shows. Attach an image if the environment supports uploads; lack
+         of attachment must not block issue creation.
        - Severity: label `bug` for broken functionality, `enhancement` for
          UX improvements.
        Do NOT push code changes for site review findings. Issues only.
@@ -103,9 +162,25 @@ env:
 
     Hard boundaries:
     - Never force-push, rewrite history, or delete branches.
-    - Never modify secrets, org settings, environments, or branch protection.
-    - Never change release workflows unless required to fix a failing run and
-      the change is scoped and explained.
+    - Never push directly to the default branch. Direct pushes are allowed
+      only to an existing non-default PR branch you are repairing under
+      category 1 or category 2.
+    - Never merge PRs, submit reviews/approvals, close/reopen PRs or
+      issues, or modify branch protection. This workflow may only push
+      fixes, open/update PRs, open/update issues, and comment on PRs when
+      a fix was pushed.
+    - Never modify secrets, org settings, environments, or branch
+      protection.
+    - Never make checks pass by disabling tests, deleting failing
+      assertions, lowering coverage/performance budgets, weakening
+      lint/type rules, or editing workflows/configuration only to suppress
+      failures.
+    - Do not modify .github/workflows/, lint/test/build config, hook
+      config, or automation prompt files unless the failing run is caused
+      by a genuine bug in that file, the change is narrowly scoped, and
+      the summary explains why.
+    - If the smallest safe fix would weaken a guardrail or reduce
+      validation, skip it and log it under "Needs Human Attention".
     - Site review (category 5) is observation-only: create issues, never
       push fixes for visual or UX findings.
     - Do not create multiple summary issues.
@@ -123,7 +198,8 @@ env:
     "Daily Autohealing Report — YYYY-MM-DD" (using today's UTC date).
     If it exists, update its body. If not, create it.
 
-    The issue body MUST use this structure:
+    The issue body MUST use this structure. If a section has no rows, do
+    not emit an empty table — write "None." directly under that heading.
 
     ## Daily Autohealing Report — YYYY-MM-DD (UTC)
 
@@ -137,13 +213,17 @@ env:
     | --- | --- | --- |
     | [advisory or #N] | Critical/High/Medium | [fix pushed / PR created / skipped] |
 
-    ### Health & Maintenance
-    | Dependency | From → To | PR |
+    ### Code Quality & Repo Hygiene
+    | Check | Result | Action |
     | --- | --- | --- |
-    | [package] | vX → vY | #N |
+    | Bundle size | ✅ Within budget / ⚠️ Over budget | [details or #N] |
+    | Test coverage | ✅ Meets thresholds / ⚠️ Below 80% | [details or #N] |
+    | Stale TODOs | N found | [#N or None] |
+    | Convention drift | ✅ Clean / ⚠️ Issues | [details or #N] |
+    | AGENTS.md accuracy | ✅ Current / ⚠️ Drifted | [#N or None] |
 
     ### Developer Experience
-    - [list of fixes applied]
+    - [list of each PR or commit-sized fix with summary link]
 
     ### Production Site Review
     | Page | Status | Issues |
@@ -156,7 +236,6 @@ env:
     ### Needs Human Attention
     - [items that could not be auto-fixed, with context]
 
-    If a section has no items, write "None" under the heading.
     Do NOT create multiple issues. Do NOT comment on individual issues.
     Produce exactly one summary issue per run.
 


### PR DESCRIPTION
- Add EXECUTION MODEL section: analyze independently, write serially, clean working tree between mutations
- Add DEDUPLICATION rule: reuse/update existing bot PRs and issues before creating new ones
- Add SCOPE CAP: escalate broad/irreversible fixes to Human Attention instead of auto-healing
- Add DEPENDENCY OWNERSHIP: Renovate owns version bumps; bot may only change versions for confirmed critical/high security advisories
- Category 1: skip dependency/security PRs; require trusted authorship; skip branches touching workflows, scripts, or lockfiles
- Category 2: skip gracefully when security alert data is unavailable
- Replace category 3 (dependency/action-pin bumps) with CODE QUALITY & REPO HYGIENE: bundle budget check, coverage threshold check, stale TODO scan, convention compliance, AGENTS.md drift check
- Category 4: avoid redundant tsc run if build already type-checks; include convention fixes found in category 3
- Category 5: add broken-layout definition, retry-before-filing rule, and clarify screenshot attachment is non-blocking
- Expand hard boundaries: explicit no-direct-push-to-default, no PR merges/approvals, no guardrail weakening, scoped workflow edits only
- Output format: rename Health & Maintenance table to Code Quality & Repo Hygiene; replace empty-table guidance with inline "None." rule